### PR TITLE
Refactor/change routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -53,18 +53,15 @@ function App() {
   const [theme, setTheme] = useState("light");
 
   return (
-    <ThemeProvider className="App" theme={themes[theme]} themes={themes}>
+    <ThemeProvider className="App" theme={themes[theme]}>
       <Routes>
         <Route index element={<Home />} />
         <Route
           path="admin"
-          element={<Layout theme={theme} setTheme={setTheme} themes={themes} />}
+          element={<Layout theme={theme} setTheme={setTheme} />}
         >
           <Route index element={<Dashboard />} />
-          <Route
-            path="users"
-            element={<AllUsers users={users} theme={themes[theme]} />}
-          />
+          <Route path="users" element={<AllUsers users={users} />} />
           <Route
             path="new"
             element={<NewUser users={users} setUsers={setUsers} />}

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Layout from "./pages/Layout";
 import Home from "./pages/Home";
 import AllUsers from "./pages/AllUsers";
 import User from "./pages/User";
+import Dashboard from "./pages/Dashboard";
 
 const initialUsers = [
   {
@@ -30,7 +31,7 @@ const darkTheme = {
   sunBgColor: "#fff",
   sunColor: "#222",
   inputBackground: "#545454",
-}
+};
 
 const lightTheme = {
   pageBackground: "#fff",
@@ -39,24 +40,31 @@ const lightTheme = {
   boxBackground: "#fff",
   topBar: "#596DC4",
   sunBgColor: "#222",
-  sunColor: "#fff"
-}
+  sunColor: "#fff",
+};
 
 const themes = {
   dark: darkTheme,
-  light: lightTheme
-}
+  light: lightTheme,
+};
 
 function App() {
   const [users, setUsers] = useState(initialUsers);
-  const [theme, setTheme] = useState('light');
+  const [theme, setTheme] = useState("light");
 
   return (
     <ThemeProvider className="App" theme={themes[theme]} themes={themes}>
       <Routes>
-        <Route path="/" element={<Layout theme={theme} setTheme={setTheme} themes={themes}/>}>
-          <Route index element={<Home />} />
-          <Route path="users" element={<AllUsers users={users} theme={themes[theme]} />} />
+        <Route index element={<Home />} />
+        <Route
+          path="admin"
+          element={<Layout theme={theme} setTheme={setTheme} themes={themes} />}
+        >
+          <Route index element={<Dashboard />} />
+          <Route
+            path="users"
+            element={<AllUsers users={users} theme={themes[theme]} />}
+          />
           <Route
             path="new"
             element={<NewUser users={users} setUsers={setUsers} />}

--- a/src/pages/AllUsers.js
+++ b/src/pages/AllUsers.js
@@ -5,6 +5,8 @@ import styled from "styled-components";
 const Table = styled.table`
   width: 100%;
   border-collapse: collapse;
+  color: ${(themes) => themes.theme.textColor};
+
   tr {
     border-bottom: 1px solid rgba(128, 128, 128, 0.45);
     th {
@@ -27,7 +29,7 @@ const Table = styled.table`
   }
 `;
 
-export default function AllUsers({ users, theme }) {
+export default function AllUsers({ users }) {
   return (
     <div className="box">
       <h1>All Users</h1>

--- a/src/pages/AllUsers.js
+++ b/src/pages/AllUsers.js
@@ -29,29 +29,29 @@ const Table = styled.table`
 
 export default function AllUsers({ users, theme }) {
   return (
-      <div className="box">
-        <h1>All Users</h1>
-        <Table>
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Balance</th>
-            </tr>
-          </thead>
-          <tbody>
-            {users &&
-              users.map((user) => {
-                return (
-                  <tr>
-                    <td>
-                      <Link to={`${user.id}`}>{user.name}</Link>
-                    </td>
-                    <td>{user.balance}</td>
-                  </tr>
-                );
-              })}
-          </tbody>
-        </Table>
-      </div>
+    <div className="box">
+      <h1>All Users</h1>
+      <Table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Balance</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users &&
+            users.map((user) => {
+              return (
+                <tr key={user.id}>
+                  <td>
+                    <Link to={`${user.id}`}>{user.name}</Link>
+                  </td>
+                  <td>{user.balance}</td>
+                </tr>
+              );
+            })}
+        </tbody>
+      </Table>
+    </div>
   );
 }

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function Dasboard() {
+  return <div>This is Dashboard</div>;
+}

--- a/src/pages/Layout.js
+++ b/src/pages/Layout.js
@@ -1,22 +1,22 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
 import { Link, NavLink, Outlet } from "react-router-dom";
 import styled from "styled-components";
 import { GiHamburgerMenu } from "react-icons/gi";
-import { FiSun, FiMoon } from "react-icons/fi";
+import { FiMoon, FiSun } from "react-icons/fi";
 
 export default function Layout({ themes, theme, setTheme }) {
   const [isSideBarOpen, setIsSideBarOpen] = useState(true);
 
   const toggleTheme = () => {
-    if (theme === 'light') {
-      setTheme('dark')  
+    if (theme === "light") {
+      setTheme("dark");
     } else {
-      setTheme('light');
+      setTheme("light");
     }
-  }
+  };
 
-  const toggleSideBar = () => isSideBarOpen ? setIsSideBarOpen(false) : setIsSideBarOpen(true)
-
+  const toggleSideBar = () =>
+    isSideBarOpen ? setIsSideBarOpen(false) : setIsSideBarOpen(true);
 
   return (
     <div>
@@ -25,21 +25,23 @@ export default function Layout({ themes, theme, setTheme }) {
           <button onClick={toggleSideBar}>
             <GiHamburgerMenu />
           </button>
-          <Link to="/">Logo</Link>
+          <Link to="/admin/">Logo</Link>
         </div>
-        <button onClick={toggleTheme}>{theme === 'light' ? <FiMoon /> : <FiSun />}</button>
+        <button onClick={toggleTheme}>
+          {theme === "light" ? <FiMoon /> : <FiSun />}
+        </button>
       </TopBar>
       <StyledLayout>
         <SideBar isSideBarOpen={isSideBarOpen}>
           <ul>
-            <StyledLink activeClassName="active" to="/users">
+            <StyledLink activeclassname="active" to="/admin/">
+              Dashboard
+            </StyledLink>
+            <StyledLink activeclassname="active" to="/admin/users">
               Users List
             </StyledLink>
-            <StyledLink activeClassName="active" to="/new">
+            <StyledLink activeclassname="active" to="/admin/new">
               Create User
-            </StyledLink>
-            <StyledLink activeClassName="active" to="/user">
-              User Dashboard
             </StyledLink>
           </ul>
         </SideBar>
@@ -54,7 +56,7 @@ export default function Layout({ themes, theme, setTheme }) {
 const StyledLink = styled(NavLink)`
   padding: 1rem;
   text-decoration: none;
-  color: ${themes => themes.theme.textColor};
+  color: ${(themes) => themes.theme.textColor};
 
   &.active {
     background: #596dc4;
@@ -64,12 +66,12 @@ const StyledLink = styled(NavLink)`
 `;
 
 const SideBar = styled.div`
-  background: ${themes => themes.theme.sideBarBackground};
+  background: ${(themes) => themes.theme.sideBarBackground};
   width: 20vw;
   padding: 2rem;
   font-weight: bold;
   font-size: 2rem;
-  position: ${props => props.isSideBarOpen ? 'absolute' : 'static'};
+  position: ${(props) => (props.isSideBarOpen ? "absolute" : "static")};
   left: -100%;
 
   div {
@@ -94,10 +96,10 @@ const OutletLayout = styled.div`
   height: 100vh;
   flex: 1;
   padding: 2rem;
-  background: ${themes => themes.theme.pageBackground};
+  background: ${(themes) => themes.theme.pageBackground};
 
   .box {
-    background: ${themes => themes.theme.boxBackground};
+    background: ${(themes) => themes.theme.boxBackground};
     border-radius: 10px;
     padding: 1rem 2rem;
     width: 80%;
@@ -105,12 +107,12 @@ const OutletLayout = styled.div`
   }
 
   h1 {
-      color: #596dc4;
-    }
+    color: #596dc4;
+  }
 `;
 
 const TopBar = styled.div`
-  background-color: ${themes => themes.theme.topBar};
+  background-color: ${(themes) => themes.theme.topBar};
   padding: 2rem;
   display: flex;
   justify-content: space-between;
@@ -121,8 +123,8 @@ const TopBar = styled.div`
     padding-top: 2px;
     border: none;
     border-radius: 100%;
-    background: ${themes => themes.theme.sunBgColor};
-    color: ${themes => themes.theme.sunColor};
+    background: ${(themes) => themes.theme.sunBgColor};
+    color: ${(themes) => themes.theme.sunColor};
     font-size: 20px;
     cursor: pointer;
   }
@@ -134,7 +136,7 @@ const TopBar = styled.div`
       background: none;
       font-size: 1.5rem;
       cursor: pointer;
-      color: ${themes => themes.theme.textColor}
+      color: ${(themes) => themes.theme.textColor};
     }
   }
-`
+`;

--- a/src/pages/Layout.js
+++ b/src/pages/Layout.js
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { GiHamburgerMenu } from "react-icons/gi";
 import { FiMoon, FiSun } from "react-icons/fi";
 
-export default function Layout({ themes, theme, setTheme }) {
+export default function Layout({ theme, setTheme }) {
   const [isSideBarOpen, setIsSideBarOpen] = useState(true);
 
   const toggleTheme = () => {


### PR DESCRIPTION
I moved the Home outside the layout routes, so that our Home will become our landing page.

I also removed unused props like `theme` and `themes` because the child components of the <ThemeProvider> can access the `themes` props like this:

```
  color: ${(themes) => themes.theme.textColor};
// or 
  color: ${(props) => props.theme.textColor};
// or
  color: ${({ theme }) => theme.textColor};
```